### PR TITLE
Fix name input width overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,16 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
-    :root {
-      color-scheme: light;
-      font-family: "Noto Serif JP", "Source Han Serif JP", serif;
-    }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      :root {
+        color-scheme: light;
+        font-family: "Noto Serif JP", "Source Han Serif JP", serif;
+      }
 
     body {
       margin: 0;


### PR DESCRIPTION
## Summary
- apply border-box sizing globally so the name input matches the button width

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfc35c6a60832ca3f61ad784c1f437